### PR TITLE
`MarkupFilters::PageLinkFilter` の挙動を修正

### DIFF
--- a/app/models/markup_filters/page_link_filter.rb
+++ b/app/models/markup_filters/page_link_filter.rb
@@ -41,7 +41,7 @@ module MarkupFilters
 
         if page_location
           text.gsub!(
-            /\[\[#{location_key.raw}\]\]/,
+            /\[\[#{Regexp.escape(location_key.raw)}\]\]/,
             view_context.render(PageLinkComponent.new(current_space: current_topic.space.not_nil!, page_location:))
           )
           text_chunk.replace(text, as: :html)

--- a/app/models/markup_filters/page_link_filter.rb
+++ b/app/models/markup_filters/page_link_filter.rb
@@ -40,11 +40,11 @@ module MarkupFilters
         page_location = page_locations.find { |page_location| page_location.key == location_key }
 
         if page_location
-          replaced_text = text.gsub(
+          text.gsub!(
             /\[\[#{location_key.raw}\]\]/,
             view_context.render(PageLinkComponent.new(current_space: current_topic.space.not_nil!, page_location:))
           )
-          text_chunk.replace(replaced_text, as: :html)
+          text_chunk.replace(text, as: :html)
         end
       end
     end

--- a/spec/models/markup_spec.rb
+++ b/spec/models/markup_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Markup, type: :model do
     page_1 = create(:page, space:, topic: topic_1, title: "Page 1")
     page_2 = create(:page, space:, topic: topic_2, title: "Page 2")
     page_3 = create(:page, space:, topic: topic_1, title: "Notebook -> List")
+    page_4 = create(:page, space:, topic: topic_1, title: "日記 (2025)")
 
     test_render_html(
       current_topic: topic_1,
@@ -169,6 +170,17 @@ RSpec.describe Markup, type: :model do
       TEXT
       expected: <<~HTML
         <p>同じ行に2つのページリンクがある場合: <a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_1.number}">Page 1</a> <a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_2.number}">Page 2</a></p>
+      HTML
+    )
+
+    test_render_html(
+      current_topic: topic_1,
+      # 正規表現において特別な意味を持つ文字がリンク記法内に含まれているとき
+      text: <<~TEXT,
+        [[日記 (2025)]]
+      TEXT
+      expected: <<~HTML
+        <p><a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_4.number}">日記 (2025)</a></p>
       HTML
     )
   end

--- a/spec/models/markup_spec.rb
+++ b/spec/models/markup_spec.rb
@@ -161,5 +161,15 @@ RSpec.describe Markup, type: :model do
         <p>文中にトピック付きのページリンクがある場合<a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_1.number}">Page 1</a>のテスト</p>
       HTML
     )
+
+    test_render_html(
+      current_topic: topic_1,
+      text: <<~TEXT,
+        同じ行に2つのページリンクがある場合: [[Page 1]] [[トピック2/Page 2]]
+      TEXT
+      expected: <<~HTML
+        <p>同じ行に2つのページリンクがある場合: <a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_1.number}">Page 1</a> <a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_2.number}">Page 2</a></p>
+      HTML
+    )
   end
 end

--- a/spec/models/markup_spec.rb
+++ b/spec/models/markup_spec.rb
@@ -38,39 +38,113 @@ RSpec.describe Markup, type: :model do
     page_1 = create(:page, space:, topic: topic_1, title: "Page 1")
     page_2 = create(:page, space:, topic: topic_2, title: "Page 2")
     page_3 = create(:page, space:, topic: topic_1, title: "Notebook -> List")
-    actual = Markup.new(current_topic: topic_1).render_html(
-      text: [
-        "- Test",
-        "- [[Page 1]]",
-        "- [[トピック1/Page 1]]",
-        # Page 2はトピック2に属しているのでリンクにならないはず
-        "- [[トピック1/Page 2]]",
-        "- [[Page 2]]",
-        "- [[トピック2/Page 2]]",
-        "- [[存在しないページ]]",
-        # `->` が含まれているとリンクにならないことがあったので追加 (リンクになるべき)
-        "- [[Notebook -> List]]",
-        "\n",
-        "文中にページリンクがある場合[[Page 1]]のテスト",
-        "\n",
-        "文中にトピック付きのページリンクがある場合[[トピック1/Page 1]]のテスト"
-      ].join("\n")
-    )
+
+    text = <<~HTML
+      - Test
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
     expected = <<~HTML
       <ul>
         <li>Test</li>
+      </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      - [[Page 1]]
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
+      <ul>
         <li><a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_1.number}">Page 1</a></li>
+      </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      - [[トピック1/Page 1]]
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
+      <ul>
         <li><a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_1.number}">Page 1</a></li>
+      </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      - [[トピック1/Page 2]]
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    # Page 2はトピック2に属しているのでリンクにならないはず
+    expected = <<~HTML
+      <ul>
         <li>[[トピック1/Page 2]]</li>
+      </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      - [[Page 2]]
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
+      <ul>
         <li>[[Page 2]]</li>
+      </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      - [[トピック2/Page 2]]
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
+      <ul>
         <li><a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_2.number}">Page 2</a></li>
+      </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      - [[存在しないページ]]
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
+      <ul>
         <li>[[存在しないページ]]</li>
+      </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    # `->` が含まれているとリンクにならないことがあったので追加 (リンクになるべき)
+    text = <<~HTML
+      - [[Notebook -> List]]
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
+      <ul>
         <li><a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_3.number}">Notebook -&gt; List</a></li>
       </ul>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      文中にページリンクがある場合[[Page 1]]のテスト
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
       <p>文中にページリンクがある場合<a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_1.number}">Page 1</a>のテスト</p>
+    HTML
+    expect(normalize_html(actual)).to eq(normalize_html(expected))
+
+    text = <<~HTML
+      文中にトピック付きのページリンクがある場合[[トピック1/Page 1]]のテスト
+    HTML
+    actual = Markup.new(current_topic: topic_1).render_html(text:)
+    expected = <<~HTML
       <p>文中にトピック付きのページリンクがある場合<a class="link link-primary" href="/s/#{space.identifier}/pages/#{page_1.number}">Page 1</a>のテスト</p>
     HTML
-
     expect(normalize_html(actual)).to eq(normalize_html(expected))
   end
 end


### PR DESCRIPTION
Fix: https://github.com/wikinoapp/wikino/issues/435
Fix: https://github.com/wikinoapp/wikino/issues/459