### PR TITLE
`ContentScreen::Large` を廃止

### DIFF
--- a/app/components/container_component.rb
+++ b/app/components/container_component.rb
@@ -14,7 +14,6 @@ class ContainerComponent < ApplicationComponent
     enums do
       Small = new("sm")
       Medium = new("md")
-      Large = new("lg")
     end
   end
 
@@ -46,8 +45,6 @@ class ContainerComponent < ApplicationComponent
       "max-w-2xl" # 672px
     when ContentScreen::Medium
       "max-w-4xl" # 896px
-    when ContentScreen::Large
-      "max-w-5xl" # 1024px
     else
       T.absurd(cs)
     end

--- a/app/components/footers/page_component.html.erb
+++ b/app/components/footers/page_component.html.erb
@@ -15,7 +15,7 @@
         <%= t("nouns.backlinks") %>
       </h2>
 
-      <div class="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-5">
+      <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
         <%= render BacklinkListComponent.new(page_entity:, backlink_list_entity:) %>
       </div>
     </div>

--- a/app/components/headers/global_component.html.erb
+++ b/app/components/headers/global_component.html.erb
@@ -7,7 +7,7 @@
     ") %>"
     data-controller="stuck"
   >
-    <div class="navbar mx-auto min-h-[auto] w-full max-w-screen-lg px-4 py-0">
+    <div class="navbar mx-auto min-h-[auto] w-full max-w-4xl px-4 py-0">
       <div class="gap-4 md:navbar-start">
         <%= render Links::BrandIconComponent.new(current_page_name:) %>
 

--- a/app/components/link_list_component.html.erb
+++ b/app/components/link_list_component.html.erb
@@ -1,13 +1,13 @@
 <div class="flex flex-col gap-2">
   <% link_entities.each do |link_entity| %>
-    <div class="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-5">
+    <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
       <%= render Cards::PageComponent.new(page_entity: link_entity.page_entity) %>
       <%= render BacklinkListComponent.new(page_entity:, backlink_list_entity: link_entity.backlink_list_entity) %>
     </div>
   <% end %>
 
   <% if pagination_entity.has_next? %>
-    <turbo-frame class="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-5" id="link-collection">
+    <turbo-frame class="grid grid-cols-2 gap-2 md:grid-cols-4" id="link-collection">
       <%= render Buttons::LinkPaginationComponent.new(
         path: page_link_list_path(space_entity.identifier, page_entity.number, after: pagination_entity.next_cursor)
       ) %>

--- a/app/views/home/show_view.html.erb
+++ b/app/views/home/show_view.html.erb
@@ -6,7 +6,6 @@
   <%= layout.with_main do %>
     <%= render ContainerComponent.new(
       as: ContainerComponent::As::Main,
-      content_screen: ContainerComponent::ContentScreen::Large,
       class_name: "flex flex-col gap-6 px-4"
     ) do %>
       <h1 class="text-2xl font-bold antialiased">

--- a/app/views/spaces/show_view.html.erb
+++ b/app/views/spaces/show_view.html.erb
@@ -4,9 +4,7 @@
   <% end %>
 
   <%= layout.with_main do %>
-    <%= render Containers::MainComponent.new(
-      content_screen: ContainerComponent::ContentScreen::Large
-    ) do %>
+    <%= render Containers::MainComponent.new do %>
       <div class="flex items-center justify-between">
         <h1 class="text-2xl font-bold antialiased">
           <%= space_entity.name %>
@@ -29,7 +27,7 @@
         <div class="flex flex-col gap-6">
           <div class="flex flex-col gap-4">
             <% if pinned_page_entities.present? %>
-              <div class="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-5">
+              <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
                 <% pinned_page_entities.each do |page_entity| %>
                   <%= render Cards::PageComponent.new(page_entity:) %>
                 <% end %>
@@ -37,7 +35,7 @@
             <% end %>
 
             <% if page_entities.present? %>
-              <div class="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-5">
+              <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
                 <% page_entities.each do |page_entity| %>
                   <%= render Cards::PageComponent.new(page_entity:) %>
                 <% end %>

--- a/app/views/topics/show_view.html.erb
+++ b/app/views/topics/show_view.html.erb
@@ -9,7 +9,6 @@
 
   <%= layout.with_main do %>
     <%= render Containers::MainComponent.new(
-      content_screen: ContainerComponent::ContentScreen::Large
     ) do %>
       <%= render Topics::ShowView::HeaderComponent.new(topic_entity:) %>
 
@@ -17,7 +16,7 @@
         <div class="flex flex-col gap-6">
           <div class="flex flex-col gap-4">
             <% if pinned_page_entities.present? %>
-              <div class="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-5">
+              <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
                 <% pinned_page_entities.each do |page_entity| %>
                   <%= render Cards::PageComponent.new(page_entity:, show_topic_name: false) %>
                 <% end %>
@@ -25,7 +24,7 @@
             <% end %>
 
             <% if page_entities.present? %>
-              <div class="grid grid-cols-2 gap-2 md:grid-cols-4 xl:grid-cols-5">
+              <div class="grid grid-cols-2 gap-2 md:grid-cols-4">
                 <% page_entities.each do |page_entity| %>
                   <%= render Cards::PageComponent.new(page_entity:, show_topic_name: false) %>
                 <% end %>

--- a/app/views/trash/show_view.html.erb
+++ b/app/views/trash/show_view.html.erb
@@ -8,9 +8,7 @@
   <% end %>
 
   <%= layout.with_main do %>
-    <%= render Containers::MainComponent.new(
-      content_screen: ContainerComponent::ContentScreen::Large
-    ) do %>
+    <%= render Containers::MainComponent.new do %>
       <div class="flex items-center justify-between">
         <div class="flex flex-col gap-2">
           <h1 class="text-2xl font-bold antialiased">


### PR DESCRIPTION
- ページリンクのグリッド列をなるべく多くして一覧性を上げるために横幅を広めにしていた
- しかしあんまり列が多いと視線移動が大変で見たいページが見つけづらい気がした
- 列が多くなくて良いなら、ページの横幅も広くなくて良い