### PR TITLE
サービスクラスの中で発生する可能性があるエラーをハンドリングできるようにする

### DIFF
--- a/app/controllers/spaces/create_controller.rb
+++ b/app/controllers/spaces/create_controller.rb
@@ -26,7 +26,7 @@ module Spaces
       flash[:notice] = t("messages.spaces.created")
       redirect_to space_path(result.space_record.identifier)
     rescue ApplicationService::RecordNotUniqueError => e
-      form.errors.add(e.attribute, e.message)
+      form.not_nil!.errors.add(e.attribute, e.message)
       render_new_view(form:)
     end
 

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -17,7 +17,11 @@ class ApplicationService
     end
   end
 
-  sig { params(block: T.proc.void).void }
+  sig do
+    type_parameters(:T)
+      .params(block: T.proc.returns(T.type_parameter(:T)))
+      .returns(T.type_parameter(:T))
+  end
   private def with_transaction(&block)
     ApplicationRecord.transaction(&block)
   rescue ActiveRecord::RecordNotUnique => e

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -17,6 +17,7 @@ class ApplicationService
     end
   end
 
+  sig { params(block: T.proc.void).void }
   private def with_transaction(&block)
     ApplicationRecord.transaction(&block)
   rescue ActiveRecord::RecordNotUnique => e

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -3,4 +3,33 @@
 
 class ApplicationService
   extend T::Sig
+
+  class RecordNotUniqueError < StandardError
+    extend T::Sig
+
+    sig { returns(Symbol) }
+    attr_reader :attribute
+
+    sig { params(message: String, attribute: Symbol).void }
+    def initialize(message:, attribute: :base)
+      super(message)
+      @attribute = attribute
+    end
+  end
+
+  private def with_transaction(&block)
+    ApplicationRecord.transaction(&block)
+  rescue ActiveRecord::RecordNotUnique => e
+    message = I18n.t("services.errors.messages.uniqueness")
+
+    # PostgreSQLの場合のエラーメッセージ例:
+    # "PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_pages_on_slug""
+    case e.message
+    when /index_space_members_on_space_id_and_user_id/
+      raise RecordNotUniqueError.new(message:, attribute: :identifier)
+    else
+      # 予期しない一意性制約違反はシステムエラーとして扱う
+      raise
+    end
+  end
 end

--- a/app/services/application_service.rb
+++ b/app/services/application_service.rb
@@ -30,7 +30,7 @@ class ApplicationService
     # PostgreSQLの場合のエラーメッセージ例:
     # "PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_pages_on_slug""
     case e.message
-    when /index_space_members_on_space_id_and_user_id/
+    when /index_spaces_on_identifier/
       raise RecordNotUniqueError.new(message:, attribute: :identifier)
     else
       # 予期しない一意性制約違反はシステムエラーとして扱う

--- a/app/services/space_service/create.rb
+++ b/app/services/space_service/create.rb
@@ -12,7 +12,8 @@ module SpaceService
       current_time = T.let(Time.current, ActiveSupport::TimeWithZone)
 
       space_record = with_transaction do
-        new_space_record = SpaceRecord.where(identifier:).first_or_create!(
+        new_space_record = SpaceRecord.create!(
+          identifier:,
           name:,
           plan: Plan::Free.serialize,
           joined_at: current_time

--- a/app/services/space_service/create.rb
+++ b/app/services/space_service/create.rb
@@ -11,7 +11,7 @@ module SpaceService
     def call(user_record:, identifier:, name:)
       current_time = T.let(Time.current, ActiveSupport::TimeWithZone)
 
-      space_record = ActiveRecord::Base.transaction do
+      space_record = with_transaction do
         new_space_record = SpaceRecord.where(identifier:).first_or_create!(
           name:,
           plan: Plan::Free.serialize,

--- a/config/locales/services.en.yml
+++ b/config/locales/services.en.yml
@@ -1,0 +1,5 @@
+en:
+  services:
+    errors:
+      messages:
+        uniqueness: has already been taken

--- a/config/locales/services.ja.yml
+++ b/config/locales/services.ja.yml
@@ -1,0 +1,5 @@
+ja:
+  services:
+    errors:
+      messages:
+        uniqueness: は既に存在しています


### PR DESCRIPTION
ref: https://wikino.app/s/shimbaco/pages/657

業務エラーをFormで行っていたのでサービスクラスではエラーハンドリングをしていなかったけど、例えば `ActiveRecord::RecordNotUnique` は発生する可能性があり、これは業務エラーとして処理すべきエラーなので、サービスクラスの中で発生したエラーを業務エラーとして吸収できるようにした。