### PR TITLE
画像を添付したときheight属性を入力しないようにする

### DIFF
--- a/app/javascript/markdown-editor/upload-placeholder.ts
+++ b/app/javascript/markdown-editor/upload-placeholder.ts
@@ -59,9 +59,9 @@ export function replacePlaceholderWithUrl(
   let newText: string;
 
   if (fileType?.startsWith("image/")) {
-    // 画像の場合は<img>タグを使用
-    if (width && height) {
-      newText = `<img width="${width}" height="${height}" alt="${altText || fileName}" src="${url}">`;
+    // 画像の場合は<img>タグを使用（heightは除外）
+    if (width) {
+      newText = `<img width="${width}" alt="${altText || fileName}" src="${url}">`;
     } else {
       newText = `<img alt="${altText || fileName}" src="${url}">`;
     }

--- a/app/models/markup/attachment_filter.rb
+++ b/app/models/markup/attachment_filter.rb
@@ -67,9 +67,8 @@ class Markup
 
       # インライン表示可能な画像形式かチェック
       if can_display_inline_image?(attachment)
-        # 元のwidth/height/alt属性を取得
+        # 元のwidth/alt属性を取得（heightは除外）
         width_attr = element["width"]
-        height_attr = element["height"]
         alt_attr = element["alt"] || attachment.filename
 
         # プレースホルダーとして表示（署名付きURLは後でJavaScriptで置換）
@@ -81,7 +80,6 @@ class Markup
           "class=\"wikino-attachment-image\""
         ]
         img_attrs << "width=\"#{width_attr}\"" if width_attr
-        img_attrs << "height=\"#{height_attr}\"" if height_attr
 
         # a要素で囲む（href属性も後でJavaScriptで設定）
         link_html = <<~HTML

--- a/spec/models/markup/attachment_filter_spec.rb
+++ b/spec/models/markup/attachment_filter_spec.rb
@@ -480,7 +480,6 @@ RSpec.describe "Markup::AttachmentFilter", type: :model do
             alt="600x400.png"
             class="wikino-attachment-image"
             width="600"
-            height="400"
           />
         </a>
       </p>
@@ -526,7 +525,6 @@ RSpec.describe "Markup::AttachmentFilter", type: :model do
             alt="600x400.png"
             class="wikino-attachment-image"
             width="600"
-            height="400"
           />
         </a>
         <br />


### PR DESCRIPTION
Fix: https://wikino.app/s/wikino/pages/166